### PR TITLE
fix download screen

### DIFF
--- a/src/d_clisrv.c
+++ b/src/d_clisrv.c
@@ -2653,16 +2653,27 @@ static boolean CL_ServerConnectionTicker(const char *tmpsave, tic_t *oldtic, tic
 #ifndef NONET
 		if (client && cl_mode != CL_CONNECTED && cl_mode != CL_ABORTED)
 		{
-			if (!snake)
-			{
-				F_MenuPresTicker(); // title sky
-				F_TitleScreenTicker(true);
-			}
 			if (!I_AppOnBackground())
 			{
-				if (!snake)
+				if (!snake || (snake && cl_mode != CL_DOWNLOADFILES && cl_mode != CL_DOWNLOADSAVEGAME))
+				{
+					F_MenuPresTicker(); // title sky
+					F_TitleScreenTicker(true);
 					F_TitleScreenDrawer();
+				}
 				CL_DrawConnectionStatus();
+				if (moviemode)
+					M_SaveFrame();
+#ifdef HAVE_THREADS
+				I_lock_mutex(&m_menu_mutex);
+#endif
+				M_Drawer(); //Needed for drawing messageboxes on the connection screen
+#ifdef HAVE_THREADS
+				I_unlock_mutex(m_menu_mutex);
+#endif
+				I_UpdateNoVsync(); // page flip or blit buffer
+				if (moviemode)
+					M_SaveFrame();
 			}
 			S_UpdateSounds();
 			S_UpdateClosedCaptions();


### PR DESCRIPTION
Fixes weird issue where the game locks up when the server has addons you need to download (might also happen with addons already saved, but I'm not sure)  

resolves #59, #63, #64, #66, and bug 2 on #71