### PR TITLE
Add Notch Support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -45,7 +45,7 @@
         android:icon="@mipmap/ic_launcher"
         android:isGame="true"
         android:allowBackup="true"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+        android:theme="@style/AppTheme"
         android:hardwareAccelerated="true" >
 
         <activity android:name="SRB2Game"

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,8 +1,7 @@
 <resources>
 
-    <!-- Base application theme. -->
-    <style name="AppTheme" parent="android:Theme.Holo.Light.DarkActionBar">
-        <!-- Customize your theme here. -->
+    <style name="AppTheme" parent="android:Theme.NoTitleBar.Fullscreen">
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Normally, a black bar will appear in the notch area of the screen (example in image),

![81 Sem Título_20240114172303~3](https://github.com/SRB2-Mobile/SRB2-Android/assets/98623902/2b6f02f0-971e-4a37-a1f2-afc127907714)

This patch removes this, making the content of the screen appear in this area (example in image).

![81 Sem Título_20240114172303~4](https://github.com/SRB2-Mobile/SRB2-Android/assets/98623902/28213909-6add-40b5-80b7-d134a369daf0)